### PR TITLE
feat(service): add https re-direct port

### DIFF
--- a/charts/authentik/templates/service.yaml
+++ b/charts/authentik/templates/service.yaml
@@ -45,6 +45,9 @@ spec:
   publishNotReadyAddresses: {{ . }}
   {{- end }}
   ports:
+    - name: https
+      port: 443
+      targetPort: 9443
     - port: 9300
       name: http-metrics
       protocol: TCP


### PR DESCRIPTION
useful for internal-only tls using default cert