### PR TITLE
fix(chart): split out resource clean up rbac

### DIFF
--- a/charts/authentik/templates/resource-cleanup.yaml
+++ b/charts/authentik/templates/resource-cleanup.yaml
@@ -10,8 +10,14 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
     "helm.sh/hook-weight": "1"
 rules:
-- apiGroups: ["","apps","rbac.authorization.k8s.io","batch","monitoring.coreos.com"]
-  resources: ["deployments", "services", "secrets","servicemonitors"]
+- apiGroups: [""]
+  resources: ["services", "secrets"]
+  verbs: ["get","list","delete"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get","list","delete"]
+- apiGroups: ["monitoring.coreos.com"]
+  resources: ["servicemonitors"]
   verbs: ["get","list","delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Fixes mixed `apiGroup` / `resource` role grants:


```
{APIGroups:[""], Resources:["servicemonitors"], Verbs:["get" "list" "delete"]}
{APIGroups:["apps"], Resources:["secrets"], Verbs:["get" "list" "delete"]}
{APIGroups:["apps"], Resources:["servicemonitors"], Verbs:["get" "list" "delete"]}
{APIGroups:["batch"], Resources:["deployments"], Verbs:["get" "list" "delete"]}
{APIGroups:["batch"], Resources:["secrets"], Verbs:["get" "list" "delete"]}
{APIGroups:["batch"], Resources:["servicemonitors"], Verbs:["get" "list" "delete"]}
{APIGroups:["batch"], Resources:["services"], Verbs:["get" "list" "delete"]}
{APIGroups:["monitoring.coreos.com"], Resources:["deployments"], Verbs:["get" "list" "delete"]}
{APIGroups:["monitoring.coreos.com"], Resources:["secrets"], Verbs:["get" "list" "delete"]}
{APIGroups:["monitoring.coreos.com"], Resources:["services"], Verbs:["get" "list" "delete"]}
```