### PR TITLE
feat(blueprints): separate user passwords blueprint

### DIFF
--- a/charts/authentik/templates/_helpers.tpl
+++ b/charts/authentik/templates/_helpers.tpl
@@ -218,6 +218,7 @@ envValueFrom:
 blueprints:
   - {{ .Release.Name }}-ldap-provider-blueprint
   - {{ .Release.Name }}-users-blueprint
+  - {{ .Release.Name }}-users-passwords-blueprint
   - {{ .Release.Name }}-groups-blueprint
   - {{ .Release.Name }}-ldap-federation-blueprint
   - {{ .Release.Name }}-google-ldap-mapping-blueprint

--- a/charts/authentik/templates/users-blueprint.yaml
+++ b/charts/authentik/templates/users-blueprint.yaml
@@ -19,6 +19,11 @@ data:
         identifiers:
           name: Custom Blueprints - Groups
         required: {{ empty ((.Values).customBlueprints).groups | not }}
+    - model: authentik_blueprints.metaapplyblueprint
+      attrs:
+        identifiers:
+          name: Custom Blueprints - User Passwords
+        required: true
     {{- range ((.Values).customBlueprints).users }}
     - attrs:
         {{- if .attributes }}
@@ -38,13 +43,12 @@ data:
         is_active: {{ default "true" .isActive }}
         {{- if .email }}
         email: {{ .email }}{{- end }}
-        password: !Env [{{ printf "%s_password" .userName }}, changeme]
       conditions: []
       id: {{ .userName }}
       identifiers:
         name: {{ .name }}
       model: authentik_core.user
-      state: {{ default "created" .state }}
+      state: {{ default "present" .state }}
     {{- end }}
 kind: ConfigMap
 metadata:

--- a/charts/authentik/templates/users-passwords-blueprint.yaml
+++ b/charts/authentik/templates/users-passwords-blueprint.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+data:
+  users-passwords-blueprint.yaml: |
+    # yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+    context: {}
+    metadata:
+      labels:
+        blueprints.goauthentik.io/instantiate: "{{ empty ((.Values).customBlueprints).users | not }}"
+      name: Custom Blueprints - User Passwords
+    version: 1
+    entries:
+    - model: authentik_blueprints.metaapplyblueprint
+      attrs:
+        identifiers:
+          name: Default - Password change flow
+        required: false
+    {{- range ((.Values).customBlueprints).users }}
+    - attrs:
+        name: {{ .name }}
+        path: {{ default "users" .path }}
+        username: {{ .userName }}
+        password: !Env [{{ printf "%s_password" .userName }}, changeme]
+      conditions: []
+      id: {{ .userName }}
+      identifiers:
+        name: {{ .name }}
+      model: authentik_core.user
+      state: {{ default "created" .passwordState }}
+    {{- end }}
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-users-passwords-blueprint
+  labels:
+    {{- include "authentik.labels" $ | nindent 4 }}

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -54,6 +54,8 @@ customBlueprints: {}
 #  - name: "Jane Doe"
 #    userName: "jdoe"
 #    email: "jdoe@bar.com"
+#    state: present # Default, reconcile changes
+#    passwordState: created # Default, only set default password once
 #    attributes:
 #      homeDirectory: "/home/jdoe"
 #      loginShell: "/bin/sh"
@@ -66,8 +68,9 @@ customBlueprints: {}
 #      attributes:
 #        foo: bar
 #    - name: basic-admin
+#      isSuperUser: true #Authentik admin group
 #      attributes:
-#        isAdmin: true
+#        foo: bar
 # -- Create an OIDC provider(s)
 #  oidcProvider:
 #    name: oidc-k8s


### PR DESCRIPTION
Allows reconciling user changes without changing password