### PR TITLE
test: Add ability to set a static ldapsvc password

### DIFF
--- a/charts/authentik/templates/secret-keys.yaml
+++ b/charts/authentik/templates/secret-keys.yaml
@@ -14,7 +14,7 @@ type: Opaque
 data:
   secret_key: {{ randAlphaNum 49 | b64enc }}
   akadmin_password: {{ randAlphaNum 16 | b64enc }}
-  ldapsvc_password: {{ randAlphaNum 16 | b64enc }}
+  ldapsvc_password: {{ default (randAlphaNum 16) .Values.ldapsvcPassword | b64enc }}
   bootstrap_token: {{ randAlphaNum 32 | b64enc }}
   admin_email: {{ (default "foo@bar.com" .Values.adminEmail ) | b64enc }}
 {{- end}}


### PR DESCRIPTION
This allows a user to specify ldapsvcPassword=somepass to use a pregenerated password.

Since this is intended for testing use, I didn't add a field to the values file.