### PR TITLE
publish: add 2024.12.3 to chart server

### DIFF
--- a/charts/authentik/Chart.yaml
+++ b/charts/authentik/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
-version: 2025.2.1
-appVersion: 2025.2.1
+version: 2024.12.3
+appVersion: 2024.12.3
 name: authentik
 description: authentik is an open-source Identity Provider focused on flexibility and versatility
 type: application


### PR DESCRIPTION
Temporarily sets Chart.yaml to 2024.12.3 to publish the missing intermediate version to the ORD1 chart server.

The 2024.12.x bumps were committed to main but only merged to coreweave all at once on 2025-03-01 (commit 6abbe63e). The GitLab CI only packages the HEAD version of coreweave, so only 2025.2.1 was published. The intermediate 2024.12.x versions were never individually on the coreweave branch and were never published to the chart server.

This creates a gap for customers doing sequential Authentik upgrades (2024.10.2 -> 2024.12.x -> 2025.2.1). Authentik requires sequential major version upgrades - skipping 2024.12 trips the 0056_user_roles migration which hangs and takes down LDAP/SSH auth (inci-1916, upstream goauthentik/authentik#20667).

After merge triggers CI to publish 2024.12.3, revert Chart.yaml back to 2025.2.1.

Customer: NovelAI (SR-6972, [supp-26245](https://coreweave.enterprise.slack.com/archives/C0BNW34JSQ1))
Customer Slack Thread: https://coreweave.slack.com/archives/C0260LPLZ8Q/p1786124780640459